### PR TITLE
rename xivo-confd-client to wazo-confd-client

### DIFF
--- a/bin/change-pass-vm
+++ b/bin/change-pass-vm
@@ -11,7 +11,7 @@ from xivo.config_helper import (
     read_config_file_hierarchy,
 )
 from wazo_auth_client import Client as AuthClient
-from xivo_confd_client import Client as ConfdClient
+from wazo_confd_client import Client as ConfdClient
 
 
 _DEFAULT_CERT_FILE = '/usr/share/xivo-certs/server.crt'

--- a/debian/control
+++ b/debian/control
@@ -17,9 +17,10 @@ Depends: ${python:Depends},
          python-jinja2,
          python-unidecode,
          wazo-auth-client,
+         wazo-confd-client-python3,
+         wazo-confd-client,
          wazo-dird-client,
          xivo-agentd-client,
-         xivo-confd-client,
          xivo-lib-python (>> 15.18),
          xivo-libdao
 Conflicts: xivo-utils (<= 18.09~20180808.174753.0834260.deb9)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
 git+https://github.com/wazo-pbx/wazo-auth-client.git
+git+https://github.com/wazo-pbx/wazo-confd-client.git
 git+https://github.com/wazo-pbx/xivo-agentd-client.git
 git+https://github.com/wazo-pbx/xivo-dao.git
 git+https://github.com/wazo-pbx/wazo-dird-client.git
 git+https://github.com/wazo-pbx/xivo-lib-python.git
 git+https://github.com/wazo-pbx/xivo-lib-rest-client.git
-git+https://github.com/wazo-pbx/xivo-confd-client.git
 jinja2==2.10.1
 psycopg2==2.6.2
 pytz==2016.7

--- a/xivo_agid/bin/agid.py
+++ b/xivo_agid/bin/agid.py
@@ -7,6 +7,7 @@ import logging
 import xivo_dao
 
 from wazo_auth_client import Client as AuthClient
+from wazo_confd_client import Client as ConfdClient
 from wazo_dird_client import Client as DirdClient
 from xivo.chain_map import ChainMap
 from xivo.config_helper import parse_config_file
@@ -16,7 +17,6 @@ from xivo.token_renewer import TokenRenewer
 from xivo.user_rights import change_user
 from xivo.xivo_logging import setup_logging, silence_loggers
 from xivo_agentd_client import Client as AgentdClient
-from xivo_confd_client import Client as ConfdClient
 
 from xivo_agid import agid
 from xivo_agid.modules import *


### PR DESCRIPTION
wazo-confd-client-python3 has been added because the script
change-vm-pass use python3