### PR TITLE
is_registered_and_mobile: handle multiple contacts

### DIFF
--- a/wazo_agid/helpers.py
+++ b/wazo_agid/helpers.py
@@ -16,12 +16,16 @@ def is_webrtc(agi, protocol, name):
 
 
 def is_registered_and_mobile(agi, aor_name):
-    contact = agi.get_variable('PJSIP_AOR({},contact)'.format(aor_name))
-    if not contact:
+    raw_contacts = agi.get_variable('PJSIP_AOR({},contact)'.format(aor_name))
+    if not raw_contacts:
         return False
 
-    mobility = agi.get_variable('PJSIP_CONTACT({},mobility)'.format(contact))
-    return mobility == 'mobile'
+    for contact in raw_contacts.split(','):
+        mobility = agi.get_variable('PJSIP_CONTACT({},mobility)'.format(contact))
+        if mobility == 'mobile':
+            return True
+
+    return False
 
 
 class CallRecordingNameGenerator(object):

--- a/wazo_agid/tests/test_helpers.py
+++ b/wazo_agid/tests/test_helpers.py
@@ -1,11 +1,73 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2018 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2019 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import unittest
-from hamcrest import assert_that, equal_to, greater_than
+from hamcrest import (
+    assert_that,
+    equal_to,
+    greater_than,
+)
+from mock import Mock
 
-from ..helpers import CallRecordingNameGenerator
+from ..helpers import (
+    CallRecordingNameGenerator,
+    is_registered_and_mobile,
+)
+
+
+class TestIsRegisteredAndMobile(unittest.TestCase):
+
+    def test_no_registered_contacts(self):
+        agi = Mock()
+        agi.get_variable.return_value = ''
+
+        result = is_registered_and_mobile(agi, 'name')
+
+        assert_that(result, equal_to(False))
+
+    def test_one_contact_not_mobile(self):
+        def get_variable(key):
+            variables = {
+                'PJSIP_AOR(name,contact)': 'the-contact',
+            }
+            return variables.get(key, '')
+
+        agi = Mock()
+        agi.get_variable.side_effect = get_variable
+
+        result = is_registered_and_mobile(agi, 'name')
+
+        assert_that(result, equal_to(False))
+
+    def test_multiple_contacts_no_mobile(self):
+        def get_variable(key):
+            variables = {
+                'PJSIP_AOR(name,contact)': 'contact;1,contact;2,contact;3',
+            }
+            return variables.get(key, '')
+
+        agi = Mock()
+        agi.get_variable.side_effect = get_variable
+
+        result = is_registered_and_mobile(agi, 'name')
+
+        assert_that(result, equal_to(False))
+
+    def test_multiple_contacts_one_mobile(self):
+        def get_variable(key):
+            variables = {
+                'PJSIP_AOR(name,contact)': 'contact;1,contact;2,contact;3',
+                'PJSIP_CONTACT(contact;2,mobility)': 'mobile',
+            }
+            return variables.get(key, '')
+
+        agi = Mock()
+        agi.get_variable.side_effect = get_variable
+
+        result = is_registered_and_mobile(agi, 'name')
+
+        assert_that(result, equal_to(True))
 
 
 class TestCallRecordingNameGenerator(unittest.TestCase):


### PR DESCRIPTION
the result of PJSIP_AOR(,contact) is a coma separated list of contacts and each
contact should be checked