### PR TITLE
[WP-2036] Agents: add enpoint information to login

### DIFF
--- a/integration_tests/suite/helpers/agentd.py
+++ b/integration_tests/suite/helpers/agentd.py
@@ -5,12 +5,12 @@ class AgentdMockClient(MockServerClient):
     def __init__(self, host, port, version='1.0'):
         super().__init__(host, port, version)
 
-    def expect_agent_login(self, agent_id, tenant_uuid, context, extension):
+    def expect_agent_login(self, agent_id, tenant_uuid, context, extension, endpoint):
         self.simple_expectation(
             'POST',
             f'/agents/by-id/{agent_id}/login',
             204,
-            {'context': context, 'extension': extension},
+            {'context': context, 'extension': extension, 'endpoint': endpoint},
             headers={'Wazo-Tenant': tenant_uuid},
         )
 

--- a/integration_tests/suite/helpers/agid.py
+++ b/integration_tests/suite/helpers/agid.py
@@ -1,4 +1,4 @@
-# Copyright 2021-2024 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2021-2025 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
@@ -145,9 +145,11 @@ class _BaseAgidClient:
 
 
 class AgidClient(_BaseAgidClient):
-    def agent_login(self, tenant_uuid, agent_id, exten, context):
+    def agent_login(self, tenant_uuid, agent_id, exten, context, endpoint):
         with self._connect():
-            self._send_handler('agent_login', tenant_uuid, agent_id, exten, context)
+            self._send_handler(
+                'agent_login', tenant_uuid, agent_id, exten, context, endpoint
+            )
             variables, commands = self._process_communicate()
         return variables, commands
 

--- a/integration_tests/suite/test_handlers.py
+++ b/integration_tests/suite/test_handlers.py
@@ -243,14 +243,14 @@ def test_agent_login(base_asset: BaseAssetLaunchingHelper):
         agent['tenant_uuid'],
         extension['context'],
         extension['exten'],
-        line['name'],
+        'PJSIP/' + line['name'],
     )
     recv_vars, recv_cmds = base_asset.agid.agent_login(
         agent['tenant_uuid'],
         agent['id'],
         extension['exten'],
         extension['context'],
-        line['name'],
+        'PJSIP/' + line['name'],
     )
 
     assert recv_cmds['FAILURE'] is False

--- a/integration_tests/suite/test_handlers.py
+++ b/integration_tests/suite/test_handlers.py
@@ -236,18 +236,21 @@ def test_agent_login(base_asset: BaseAssetLaunchingHelper):
     with base_asset.db.queries() as queries:
         agent = queries.insert_agent()
         extension = queries.insert_extension()
+        line = queries.insert_line()
 
     base_asset.agentd.expect_agent_login(
         agent['id'],
         agent['tenant_uuid'],
         extension['context'],
         extension['exten'],
+        line['name'],
     )
     recv_vars, recv_cmds = base_asset.agid.agent_login(
         agent['tenant_uuid'],
         agent['id'],
         extension['exten'],
         extension['context'],
+        line['name'],
     )
 
     assert recv_cmds['FAILURE'] is False

--- a/wazo_agid/handlers/agent.py
+++ b/wazo_agid/handlers/agent.py
@@ -11,12 +11,17 @@ from wazo_agid.fastagi import FastAGI
 
 
 def login_agent(
-    agi: FastAGI, agent_id: int, extension: str, context: str, tenant_uuid: str
+    agi: FastAGI,
+    agent_id: int,
+    extension: str,
+    context: str,
+    endpoint: str,
+    tenant_uuid: str,
 ) -> None:
     agentd_client = agi.config['agentd']['client']
     try:
         agentd_client.agents.login_agent(
-            agent_id, extension, context, tenant_uuid=tenant_uuid
+            agent_id, extension, context, endpoint=endpoint, tenant_uuid=tenant_uuid
         )
     except AgentdClientError as e:
         if e.error == error.ALREADY_LOGGED:

--- a/wazo_agid/handlers/tests/test_agent.py
+++ b/wazo_agid/handlers/tests/test_agent.py
@@ -20,6 +20,7 @@ class TestAgent(unittest.TestCase):
         self.agent_id = 11
         self.extension = '1234'
         self.context = 'foobar'
+        self.endpoint = 'endpoint'
         self.tenant = 'eeeeeeee-eeee--eeee-eeee-eeeeeeeeeeee'
 
     def test_login_agent(self):
@@ -28,11 +29,16 @@ class TestAgent(unittest.TestCase):
             self.agent_id,
             self.extension,
             self.context,
-            tenant_uuid=self.tenant,
+            self.endpoint,
+            self.tenant,
         )
 
         self.agentd_client.agents.login_agent.assert_called_once_with(
-            self.agent_id, self.extension, self.context, tenant_uuid=self.tenant
+            self.agent_id,
+            self.extension,
+            self.context,
+            endpoint=self.endpoint,
+            tenant_uuid=self.tenant,
         )
         self.agi.set_variable.assert_called_once_with(dv.AGENTSTATUS, 'logged')
 
@@ -46,7 +52,8 @@ class TestAgent(unittest.TestCase):
             self.agent_id,
             self.extension,
             self.context,
-            tenant_uuid=self.tenant,
+            self.endpoint,
+            self.tenant,
         )
 
         self.agi.set_variable.assert_called_once_with(dv.AGENTSTATUS, 'already_logged')
@@ -61,7 +68,8 @@ class TestAgent(unittest.TestCase):
             self.agent_id,
             self.extension,
             self.context,
-            tenant_uuid=self.tenant,
+            self.endpoint,
+            self.tenant,
         )
 
         self.agi.set_variable.assert_called_once_with(dv.AGENTSTATUS, 'already_in_use')
@@ -76,7 +84,8 @@ class TestAgent(unittest.TestCase):
             self.agent_id,
             self.extension,
             self.context,
-            tenant_uuid=self.tenant,
+            self.endpoint,
+            self.tenant,
         )
 
     def test_logoff_agent(self):

--- a/wazo_agid/modules/agent_login.py
+++ b/wazo_agid/modules/agent_login.py
@@ -1,4 +1,4 @@
-# Copyright 2012-2024 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2012-2025 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
@@ -23,8 +23,8 @@ def agent_login(agi: FastAGI, cursor: DictCursor, args: list[str]) -> None:
         agent_id = int(args[1])
         extension = args[2]
         context = args[3]
-
-        agent.login_agent(agi, agent_id, extension, context, tenant_uuid)
+        endpoint = args[4]
+        agent.login_agent(agi, agent_id, extension, context, endpoint, tenant_uuid)
     except Exception as e:
         logger.exception("Error while logging in agent")
         agi.dp_break(e)


### PR DESCRIPTION
Depends-On: https://github.com/wazo-platform/wazo-agentd-client/pull/32

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds endpoint to agent login, wiring it through AGI module/handler, mock/integration clients, and tests to send it to agentd.
> 
> - **Handlers/Module**
>   - `login_agent(...)` now accepts `endpoint` and forwards it to `agentd_client.agents.login_agent(..., endpoint=...)`.
>   - `modules/agent_login.agent_login` parses `endpoint` from `args[4]` and passes it to the handler.
> - **Integration helpers**
>   - `AgentdMockClient.expect_agent_login(...)` includes `endpoint` in request body.
>   - `AgidClient.agent_login(...)` signature extended to include `endpoint` and sends it over FastAGI.
> - **Tests**
>   - Unit/integration tests updated to provide/validate `endpoint` in agent login calls.
> - **Misc**
>   - Copyright years bumped to 2025.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 113461ecfae66aa7ce1f20f8acd22dd574a85375. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->