### PR TITLE
[WAZO-4157] Provisioning: fix *guest

### DIFF
--- a/integration_tests/suite/helpers/confd.py
+++ b/integration_tests/suite/helpers/confd.py
@@ -16,10 +16,23 @@ class ConfdMockClient(MockServerClient):
         return response.status_code == 202
 
     def expect_devices(self, devices):
-        self.simple_expectation('GET', '/devices', 200, devices)
+        self.simple_expectation(
+            'GET',
+            '/devices',
+            200,
+            devices,
+        )
 
-    def verify_devices_called(self):
-        response = self.verify_called('GET', '/devices')
+    def verify_devices_called(self, search_term=None, negate_search=False):
+        query_string_params = {}
+        if search_term is not None:
+            if negate_search:
+                query_string_params['!search'] = '.*'
+            else:
+                query_string_params['search'] = f'{search_term}'
+        response = self.verify_called(
+            'GET', '/devices', query_string_params=query_string_params
+        )
         return response.status_code == 202
 
     def expect_devices_autoprov(self, device_id):

--- a/integration_tests/suite/helpers/mock_clients.py
+++ b/integration_tests/suite/helpers/mock_clients.py
@@ -55,7 +55,9 @@ class MockServerClient:
     def clear(self):
         return requests.put(f'{self._url}/clear')
 
-    def verify_called(self, method, path, times_called=1, **kwargs):
+    def verify_called(
+        self, method, path, times_called=1, query_string_params=None, **kwargs
+    ):
         verification = {
             'httpRequest': {
                 'method': method,
@@ -66,6 +68,8 @@ class MockServerClient:
                 'atMost': times_called,
             },
         }
+        if query_string_params is not None:
+            verification['httpRequest']['queryStringParameters'] = query_string_params
         verification.update(kwargs)
         return requests.put(f'{self._url}/verify', json=verification)
 

--- a/integration_tests/suite/test_handlers.py
+++ b/integration_tests/suite/test_handlers.py
@@ -1681,7 +1681,12 @@ def test_provision_autoprov(base_asset: BaseAssetLaunchingHelper):
         '192.168.1.1:1234',
     )
 
-    assert base_asset.confd.verify_devices_called() is True
+    assert (
+        base_asset.confd.verify_devices_called(
+            search_term='autoprov', negate_search=True
+        )
+        is True
+    )
     assert base_asset.confd.verify_devices_autoprov_called(1) is True
     assert base_asset.confd.verify_devices_synchronize_called(1) is True
     base_asset.confd.clear()
@@ -1710,7 +1715,7 @@ def test_provision_add_device(base_asset: BaseAssetLaunchingHelper):
         '192.168.1.2:1234',
     )
 
-    assert base_asset.confd.verify_devices_called() is True
+    assert base_asset.confd.verify_devices_called(search_term='autoprov') is True
     assert base_asset.confd.verify_lines_called() is True
     assert base_asset.confd.verify_lines_devices_called(1, 2) is True
     assert base_asset.confd.verify_devices_synchronize_called(2) is True

--- a/wazo_agid/modules/provision.py
+++ b/wazo_agid/modules/provision.py
@@ -21,11 +21,18 @@ TIMEOUT = 10
 
 def _do_provision(client: ConfdClient, provcode: str, ip: str) -> None:
     if provcode == "autoprov":
+        logger.debug(f"putting device with ip {ip} in autoprov mode")
         device = _get_device(client, ip)
+        logger.debug(f"device found: {device}")
         client.devices.autoprov(device['id'])
     else:
+        logger.debug(
+            f"adding device with ip {ip} to line with provisioning code {provcode}"
+        )
         line = _get_line(client, provcode)
+        logger.debug(f"line found: {line}")
         device = _get_device(client, ip, only_autoprov=True)
+        logger.debug(f"device found: {device}")
         client.lines(line).add_device(device)
     client.devices.synchronize(device['id'])
 

--- a/wazo_agid/modules/provision.py
+++ b/wazo_agid/modules/provision.py
@@ -20,17 +20,24 @@ TIMEOUT = 10
 
 
 def _do_provision(client: ConfdClient, provcode: str, ip: str) -> None:
-    device = _get_device(client, ip)
     if provcode == "autoprov":
+        device = _get_device(client, ip)
         client.devices.autoprov(device['id'])
     else:
         line = _get_line(client, provcode)
+        device = _get_device(client, ip, only_autoprov=True)
         client.lines(line).add_device(device)
     client.devices.synchronize(device['id'])
 
 
-def _get_device(client: ConfdClient, ip: str) -> dict[str, Any]:
-    response = client.devices.list(ip=ip, search='autoprov', recurse=True)
+def _get_device(
+    client: ConfdClient, ip: str, only_autoprov: bool = False
+) -> dict[str, Any]:
+    if only_autoprov:
+        response = client.devices.list(ip=ip, search='autoprov', recurse=True)
+    else:
+        response = client.devices.list(ip=ip, recurse=True)
+
     if response['total'] != 1:
         raise Exception(f"Device with ip {ip} not found")
     return response['items'][0]

--- a/wazo_agid/modules/tests/test_provision.py
+++ b/wazo_agid/modules/tests/test_provision.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2024 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2025 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
@@ -60,5 +60,6 @@ class TestDoProvision(unittest.TestCase):
 
         self.provision("autoprov", "127.0.0.1")
 
+        self.client.devices.list.assert_called_once_with(ip="127.0.0.1", recurse=True)
         self.client.devices.autoprov.assert_called_once_with(device['id'])
         self.client.devices.synchronize.assert_called_once_with(device['id'])


### PR DESCRIPTION
Details: when using *guest extension, we want to put the device
back to autoprov, so the device should not be searched with the
autoprov name, because it does not have a name beginning with
autoprov.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjust provisioning to list devices without `search=autoprov` for autoprov mode and only with it when adding to a line; extend mocks to verify query params.
> 
> - **Backend (provision)**
>   - `_do_provision`: for `provcode == "autoprov"`, fetch device via `client.devices.list(ip=..., recurse=True)` (no `search='autoprov'`); when linking to a line, fetch with `search='autoprov'`.
>   - Add concise debug logs around device/line lookups and actions.
> - **Test Helpers**
>   - `ConfdMockClient.verify_devices_called(search_term=None, negate_search=False)`: supports verifying `/devices` calls with `search` or `!search` query params.
>   - `MockServerClient.verify_called(...)`: now accepts `queryStringParameters`.
> - **Tests**
>   - Update integration and unit tests to assert the new `/devices` query behavior and maintain autoprov/synchronize flows.
>   - Refresh copyright year.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d695c4cfe4019aae0f5f73317549c35eb74d9439. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->