### PR TITLE
WAZO 3981 fix sqlalchemy warnings

### DIFF
--- a/integration_tests/assets/docker-compose.yml
+++ b/integration_tests/assets/docker-compose.yml
@@ -10,6 +10,7 @@ services:
       - "4573"
     environment:
       - PYTHONUNBUFFERED=TRUE
+      - SQLALCHEMY_WARN_20=1
     volumes:
       - "../..:/usr/src/wazo-agid"
       - "./etc/wazo-agid/conf.d/50-default.yml:/etc/wazo-agid/conf.d/50-default.yml"

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,8 @@ env_list = py311, linters
 no_package = false
 
 [testenv]
+set_env =
+    SQLALCHEMY_WARN_20=1
 commands =
     pytest --junitxml=unit-tests.xml --cov=wazo_agid --cov-report term --cov-report xml:coverage.xml wazo_agid
 deps =
@@ -15,6 +17,8 @@ base_python = python3.11
 use_develop = true
 deps = -rintegration_tests/test-requirements-for-tox.txt
 change_dir = integration_tests
+set_env =
+    SQLALCHEMY_WARN_20=1
 pass_env =
     INTEGRATION_TEST_TIMEOUT
     MANAGE_DB_DIR

--- a/wazo_agid/modules/queue_skill_rule_set.py
+++ b/wazo_agid/modules/queue_skill_rule_set.py
@@ -39,7 +39,7 @@ def queue_skill_rule_set(
         return
 
     with session_scope() as session:
-        skill_rule = session.query(QueueSkillRule).get(int(skill_rule_id))
+        skill_rule = session.get(QueueSkillRule, int(skill_rule_id))
         if not skill_rule:
             _set_variables(agi, call, timeout)
             return


### PR DESCRIPTION
- **tests: capture deprecation warnings**
- **sqlalchemy: use Session.get instead of Query.get**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces deprecated SQLAlchemy Query.get with Session.get and enables SQLAlchemy 2.0 warnings in tox and integration docker-compose.
> 
> - **Database/AGI module**:
>   - Use `session.get(QueueSkillRule, id)` in `wazo_agid/modules/queue_skill_rule_set.py` instead of deprecated `query(...).get()`.
> - **Tests/CI**:
>   - Set `SQLALCHEMY_WARN_20=1` in `tox.ini` for default and `integration` envs.
>   - Add `SQLALCHEMY_WARN_20=1` to `integration_tests/assets/docker-compose.yml` for the `agid` service.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4a5d680edcadda35c2e1d80c06e5137427cdb38b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->