### PR TITLE
WP-2118 pytest: migrate setup.cfg conf to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,3 +24,6 @@ exclude = [
 [tool.isort]
 py_version = 311
 profile = "black"
+
+[tool.pytest]
+testpaths = ["wazo_agid"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,0 @@
-[tool:pytest]
-norecursedirs = integration_tests

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,3 @@
 https://github.com/wazo-platform/wazo-test-helpers/archive/master.zip
 pyhamcrest
-pytest
+pytest>=9.0


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Moves pytest config from setup.cfg into pyproject.toml and updates test dependency to pytest>=9.0.
> 
> - **Configuration**:
>   - Move pytest config from `setup.cfg` to `pyproject.toml` via `[tool.pytest]` with `testpaths = ["wazo_agid"]`.
>   - Remove obsolete `[tool:pytest]` section from `setup.cfg`.
> - **Dependencies**:
>   - Update `test-requirements.txt` to require `pytest>=9.0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 84fbb2514e0240f0fe3237495c5465db1d8844ce. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->