### PR TITLE
Bump mypy pre-commit hook to v1.19.1

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,7 +29,7 @@ repos:
     hooks:
       - id: black
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.7.1
+    rev: v1.19.1
     hooks:
       - id: mypy
         exclude: "bin/"

--- a/wazo_agid/fastagi.py
+++ b/wazo_agid/fastagi.py
@@ -1,4 +1,4 @@
-# Copyright 2004-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2004-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 # Modifications by Proformatique from pyst-0.2:
@@ -17,7 +17,8 @@ from __future__ import annotations
 
 import pprint
 import re
-from typing import TYPE_CHECKING, Any, BinaryIO, NoReturn
+from io import BufferedIOBase
+from typing import TYPE_CHECKING, Any, NoReturn
 
 if TYPE_CHECKING:
     from typing import Literal
@@ -101,7 +102,9 @@ class FastAGI:
     Asterisk.
     """
 
-    def __init__(self, inf: BinaryIO, outf: BinaryIO, config: dict[str, Any]) -> None:
+    def __init__(
+        self, inf: BufferedIOBase, outf: BufferedIOBase, config: dict[str, Any]
+    ) -> None:
         self.inf = inf
         self.outf = outf
         self.config = config


### PR DESCRIPTION
Resolves compatibility issues with latest types-setuptools.
See WAZO-4386.

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> - Upgrade mypy pre-commit hook from `v1.7.1` to `v1.19.1` in `.pre-commit-config.yaml`
> - Update `wazo_agid/fastagi.py`: change constructor param types from `BinaryIO` to `BufferedIOBase` and adjust imports
> - Update copyright header year to `2004-2026`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cbfb6897fc837eabd3551e8a4573ad6df50781b2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->