### PR TITLE
fix: ring group user ring timeout

### DIFF
--- a/integration_tests/suite/test_handlers.py
+++ b/integration_tests/suite/test_handlers.py
@@ -1,4 +1,4 @@
-# Copyright 2021-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2021-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
@@ -1043,6 +1043,7 @@ def test_incoming_group_set_features(base_asset: BaseAssetLaunchingHelper):
     assert recv_vars['WAZO_GROUP_LABEL'] == 'incoming group set features'
     assert recv_vars[dv.GROUP_TIMEOUT] == '25'
     assert recv_vars['WAZO_GROUP_USER_TIMEOUT'] == '10'
+    assert recv_vars['__WAZO_RING_TIME'] == '10'
     assert recv_vars['WAZO_GROUP_STRATEGY'] == 'linear'
     assert recv_vars['WAZO_GROUP_RETRY_DELAY'] == '5'
     assert recv_vars[f'__{dv.GROUP_DTMF_RECORD_TOGGLE_ENABLED}'] == '1'
@@ -1101,6 +1102,7 @@ def test_incoming_group_set_features_linear_with_music(
     assert recv_vars[dv.GROUPNEEDANSWER] == '1'
     assert recv_vars[dv.GROUP_TIMEOUT] == '25'
     assert recv_vars['WAZO_GROUP_USER_TIMEOUT'] == '10'
+    assert recv_vars['__WAZO_RING_TIME'] == '10'
     assert recv_vars['WAZO_GROUP_STRATEGY'] == 'linear'
     assert recv_vars['WAZO_GROUP_RETRY_DELAY'] == '5'
 

--- a/wazo_agid/handlers/groupfeatures.py
+++ b/wazo_agid/handlers/groupfeatures.py
@@ -1,4 +1,4 @@
-# Copyright 2012-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2012-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
@@ -191,6 +191,8 @@ class GroupFeatures(Handler):
             self._agi.set_variable('WAZO_GROUP_USER_TIMEOUT', self._user_timeout)
         else:
             self._agi.set_variable('WAZO_GROUP_USER_TIMEOUT', "")
+        ring_time = self._user_timeout or ''
+        self._agi.set_variable('__WAZO_RING_TIME', ring_time)
 
         if self._group_retry_delay:
             self._agi.set_variable('WAZO_GROUP_RETRY_DELAY', self._group_retry_delay)


### PR DESCRIPTION
used by mobile wakeup push

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to a group feature variable export with integration test coverage; low risk aside from potential downstream expectations around the new `__WAZO_RING_TIME` value/emptiness.
> 
> **Overview**
> Sets a new inherited channel variable `__WAZO_RING_TIME` when applying group timeouts, mirroring the configured `WAZO_GROUP_USER_TIMEOUT` so downstream dialplan/components can reliably use the per-member ring duration.
> 
> Updates integration tests for `incoming_group_set_features` to assert that `__WAZO_RING_TIME` is exported (and bumps copyright headers to 2026).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 17099c957ee7c3d9a163d079001bbfd2e018eed4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->