### PR TITLE
Add push trace UUID tracking to mobile wake notifications

### DIFF
--- a/wazo_agid/modules/wake_mobile.py
+++ b/wazo_agid/modules/wake_mobile.py
@@ -3,11 +3,16 @@
 
 from __future__ import annotations
 
+import logging
+import uuid
+
 from datetime import datetime, timezone
 
 from psycopg2.extras import DictCursor
 
 from wazo_agid import agid
+
+logger = logging.getLogger(__name__)
 
 
 def wake_mobile(agi: agid.FastAGI, cursor: DictCursor, args: list[str]) -> None:
@@ -22,11 +27,19 @@ def wake_mobile(agi: agid.FastAGI, cursor: DictCursor, args: list[str]) -> None:
         agi.get_variable('WAZO_RING_TIME') or agi.get_variable('WAZO_RINGSECONDS') or 30
     )
     timestamp = datetime.now(tz=timezone.utc).isoformat()
+    push_trace_uuid = str(uuid.uuid4())
+
+    logger.info(
+        'Sending Pushmobile for user %s push_trace_uuid=%s',
+        user_uuid,
+        push_trace_uuid,
+    )
     agi.appexec(
         'UserEvent',
         f'Pushmobile,WAZO_DST_UUID: {user_uuid},WAZO_VIDEO_ENABLED: {video_enabled},'
         f'WAZO_RING_TIME: {ring_time},'
-        f'WAZO_TIMESTAMP: {timestamp}',
+        f'WAZO_TIMESTAMP: {timestamp},'
+        f'WAZO_PUSH_TRACE_UUID: {push_trace_uuid}',
     )
 
 


### PR DESCRIPTION
## Summary
Enhanced the `wake_mobile` module to include push notification tracing capabilities by generating and logging a unique trace UUID for each push notification sent to mobile devices.

## Key Changes
- Added `logging` and `uuid` imports for tracing functionality
- Generated a unique `push_trace_uuid` for each push notification using `uuid.uuid4()`
- Added informational logging that captures the user UUID and push trace UUID when sending push notifications
- Extended the `Pushmobile` UserEvent to include the `WAZO_PUSH_TRACE_UUID` parameter, enabling end-to-end tracing of push notifications through the system

## Implementation Details
- The trace UUID is generated as a string representation of a UUID4 value
- Logging is performed at the INFO level with structured parameters for easy log parsing and monitoring
- The push trace UUID is appended to the existing UserEvent parameters, maintaining backward compatibility with the event structure

https://claude.ai/code/session_0193K1vomcUqeAw3TAif3MCK

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new per-notification UUID and an INFO log line, plus an extra `UserEvent` field; behavior is otherwise unchanged aside from potential downstream consumers needing to ignore the new parameter.
> 
> **Overview**
> Adds push-notification tracing to `wake_mobile` by generating a per-call `push_trace_uuid`, logging it alongside the destination user UUID, and including it as `WAZO_PUSH_TRACE_UUID` in the emitted `Pushmobile` `UserEvent` payload.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 841d7ecb9241157be804ab1bc1470f9de4da874f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->