### PR TITLE
ITEM-251-group-call-recording

### DIFF
--- a/wazo_agid/handlers/tests/test_userfeatures.py
+++ b/wazo_agid/handlers/tests/test_userfeatures.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2013-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import unittest
@@ -196,6 +196,23 @@ class TestUserFeatures(_BaseTestCase):
         userfeatures._set_call_record_enabled()
 
         self._agi.set_variable.assert_not_called()
+
+    def test_set_call_record_enabled_from_group_blind_transfer(self):
+        self._variables['WAZO_FROMGROUP'] = '1'
+        self._variables['BLINDTRANSFER'] = 'PJSIP/some-channel-00000001'
+
+        userfeatures = UserFeatures(self._agi, self._cursor, self._args)
+        userfeatures._user = Mock(
+            call_record_incoming_internal_enabled=True,
+            call_record_incoming_external_enabled=True,
+        )
+        userfeatures._zone = 'intern'
+
+        userfeatures._set_call_record_enabled()
+
+        self._agi.set_variable.assert_called_once_with(
+            '__WAZO_PEER_CALL_RECORD_ENABLED', '1'
+        )
 
     @patch('wazo_agid.handlers.userfeatures.extension_dao')
     @patch('wazo_agid.handlers.userfeatures.line_extension_dao')

--- a/wazo_agid/handlers/userfeatures.py
+++ b/wazo_agid/handlers/userfeatures.py
@@ -1,4 +1,4 @@
-# Copyright 2012-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2012-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
@@ -405,7 +405,15 @@ class UserFeatures(Handler):
     def _set_call_record_enabled(self):
         is_being_recorded = self._agi.get_variable('WAZO_CALL_RECORD_ACTIVE') == '1'
         is_a_group_extension_member = self._agi.get_variable('WAZO_FROMGROUP') == '1'
-        if is_being_recorded or is_a_group_extension_member:
+
+        # group.AnswerHandler owns recording for group calls, except for blind
+        # transfer targets where it never runs.
+        is_a_blind_transfer = bool(self._agi.get_variable('BLINDTRANSFER'))
+        group_handler_will_record = (
+            is_a_group_extension_member and not is_a_blind_transfer
+        )
+
+        if is_being_recorded or group_handler_will_record:
             return
 
         is_internal = self._zone == 'intern'

--- a/wazo_agid/modules/call_recording.py
+++ b/wazo_agid/modules/call_recording.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2020-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
@@ -93,6 +93,8 @@ def _resume_call_recording(agi, calld, channel_id, tenant_uuid):
 
 
 def start_mix_monitor(agi, cursor, args):
+    if agi.get_variable('WAZO_CALL_RECORD_ACTIVE') == '1':
+        return
     _start_mix_monitor(agi)
 
 

--- a/wazo_agid/modules/tests/test_call_recording.py
+++ b/wazo_agid/modules/tests/test_call_recording.py
@@ -1,4 +1,4 @@
-# Copyright 2021-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2021-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
@@ -8,7 +8,7 @@ from unittest.mock import Mock, call, patch
 
 from wazo_agid import dialplan_variables as dv
 
-from ..call_recording import record_caller
+from ..call_recording import record_caller, start_mix_monitor
 
 
 class TestRecordCaller(TestCase):
@@ -256,3 +256,25 @@ class TestRecordCaller(TestCase):
         self.agi.get_variable.assert_has_calls(calls)
 
         start_mix_monitor.assert_called_once()
+
+
+class TestStartMixMonitor(TestCase):
+    def setUp(self):
+        self.agi = Mock()
+        self.cursor = Mock()
+
+    @patch('wazo_agid.modules.call_recording._start_mix_monitor')
+    def test_does_not_record_when_already_recording(self, mock_start):
+        self.agi.get_variable.return_value = '1'
+
+        start_mix_monitor(self.agi, self.cursor, [])
+
+        mock_start.assert_not_called()
+
+    @patch('wazo_agid.modules.call_recording._start_mix_monitor')
+    def test_records_when_not_already_recording(self, mock_start):
+        self.agi.get_variable.return_value = ''
+
+        start_mix_monitor(self.agi, self.cursor, [])
+
+        mock_start.assert_called_once()


### PR DESCRIPTION
- **fix: record call for blind transfer target from group**
- **fix: prevent duplicate MixMonitor on blind transfer**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches call recording enablement logic for group/blind-transfer scenarios and adds a guard to avoid starting MixMonitor twice, which could affect whether calls are recorded in edge cases.
> 
> **Overview**
> Fixes call recording behavior for **group blind transfers** by allowing the blind-transfer target to enable recording when `group.AnswerHandler` will not run, instead of always skipping recording for `WAZO_FROMGROUP` calls.
> 
> Adds a safeguard in `start_mix_monitor` to no-op when `WAZO_CALL_RECORD_ACTIVE=1`, preventing duplicate `MixMonitor` starts during blind transfer flows. Tests were updated/added to cover both scenarios.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7938a14a77c47b7ffc7dcfe8ee40251870eebc6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->