### PR TITLE
[ITEM-92] Set auto-recording var in shared area

### DIFF
--- a/wazo_agid/handlers/group.py
+++ b/wazo_agid/handlers/group.py
@@ -56,14 +56,15 @@ class AnswerHandler(handler.Handler):
         if not should_record:
             return
 
-        callee_channel_id = self.get_callee_channel_id()
-        if not callee_channel_id:
+        if (callee_channel := self.get_callee_channel()) is None:
             return
+
+        callee_channel_name, callee_channel_id = callee_channel
 
         calld = self._agi.config['calld']['client']
         tenant_uuid = self._agi.get_variable('WAZO_TENANT_UUID')
         self._agi.set_variable(
-            f'SHARED(WAZO_RECORD_GROUP_CALLEE,{callee_channel_id})', '1'
+            f'SHARED(WAZO_RECORD_GROUP_CALLEE,{callee_channel_name})', '1'
         )
         try:
             calld.calls.start_record(callee_channel_id, tenant_uuid=tenant_uuid)

--- a/wazo_agid/handlers/group.py
+++ b/wazo_agid/handlers/group.py
@@ -62,7 +62,9 @@ class AnswerHandler(handler.Handler):
 
         calld = self._agi.config['calld']['client']
         tenant_uuid = self._agi.get_variable('WAZO_TENANT_UUID')
-        self._agi.set_variable('WAZO_RECORD_GROUP_CALLEE', '1')
+        self._agi.set_variable(
+            f'SHARED(WAZO_RECORD_GROUP_CALLEE,{callee_channel_id})', '1'
+        )
         try:
             calld.calls.start_record(callee_channel_id, tenant_uuid=tenant_uuid)
         except Exception as e:

--- a/wazo_agid/handlers/handler.py
+++ b/wazo_agid/handlers/handler.py
@@ -29,7 +29,7 @@ class Handler:
             self._agi.set_variable(dv.PATH, path_type)
             self._agi.set_variable(dv.PATH_ID, path_id)
 
-    def get_callee_channel_id(self):
+    def get_callee_channel(self) -> tuple[str, str] | None:
         visited: set[str] = set()
         channel = self._agi.env['agi_channel']
         while channel.startswith('Local/') and channel.endswith(';1'):
@@ -48,4 +48,4 @@ class Handler:
             logger.error('Could not get uniqueid for channel %s', channel)
             return None
 
-        return callee_channel_id
+        return channel, callee_channel_id

--- a/wazo_agid/handlers/queue.py
+++ b/wazo_agid/handlers/queue.py
@@ -68,14 +68,15 @@ class AnswerHandler(handler.Handler):
         if not should_record:
             return
 
-        callee_channel_id = self.get_callee_channel_id()
-        if not callee_channel_id:
+        if (callee_channel := self.get_callee_channel()) is None:
             return
+
+        callee_channel_name, callee_channel_id = callee_channel
 
         calld = self._agi.config['calld']['client']
         tenant_uuid = self._agi.get_variable('WAZO_TENANT_UUID')
         self._agi.set_variable(
-            f'SHARED(WAZO_RECORD_QUEUE_CALLEE,{callee_channel_id})', '1'
+            f'SHARED(WAZO_RECORD_QUEUE_CALLEE,{callee_channel_name})', '1'
         )
         try:
             calld.calls.start_record(callee_channel_id, tenant_uuid=tenant_uuid)

--- a/wazo_agid/handlers/queue.py
+++ b/wazo_agid/handlers/queue.py
@@ -74,7 +74,9 @@ class AnswerHandler(handler.Handler):
 
         calld = self._agi.config['calld']['client']
         tenant_uuid = self._agi.get_variable('WAZO_TENANT_UUID')
-        self._agi.set_variable('WAZO_RECORD_QUEUE_CALLEE', '1')
+        self._agi.set_variable(
+            f'SHARED(WAZO_RECORD_QUEUE_CALLEE,{callee_channel_id})', '1'
+        )
         try:
             calld.calls.start_record(callee_channel_id, tenant_uuid=tenant_uuid)
         except Exception as e:


### PR DESCRIPTION
Why: The variable should be available from the callee's recorded channel and not the channel we're currently working on, putting the var in Asterisk's shared variables area allows us to go and grab it from anywhere within the call

WP-2020

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes call-recording control variables for queue/group calls to be channel-scoped `SHARED()` entries and updates callee-channel resolution, which could affect when/where recording is triggered in live call flows.
> 
> **Overview**
> Updates queue/group auto-recording so the “callee should be recorded” flags are written to Asterisk’s `SHARED()` variable space keyed by the resolved callee channel (instead of a local channel variable), making the flag readable from the recorded channel.
> 
> Refactors callee channel lookup from `get_callee_channel_id()` to `get_callee_channel()`, returning both the callee channel name and uniqueid so recording can set the shared variable and start recording on the correct channel.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bffeea53274cbbb67f89688a33bc5fe545dc4a89. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->