### PR TITLE
CallerID: allow spaces in non-quoted caller ID

### DIFF
--- a/wazo_agid/objects.py
+++ b/wazo_agid/objects.py
@@ -1018,7 +1018,7 @@ class Context:
 
 
 CALLERID_MATCHER = re.compile(
-    r'^ *(?:"(.+)"|([\w\-\.\!%\*_\+`\'\~ ]*[^ "])) *(?:<(\+?[0-9\*#]+)>)?$'
+    r'^ *(?:"(.+)"|([\w\-\.\!%\*\+`\'\~ ]*[^ "])) *(?:<(\+?[0-9\*#]+)>)?$'
 ).match
 CALLERIDNUM_MATCHER = re.compile(r'^\+?[0-9\*#]+$').match
 

--- a/wazo_agid/objects.py
+++ b/wazo_agid/objects.py
@@ -1,4 +1,4 @@
-# Copyright 2007-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2007-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
@@ -1018,7 +1018,7 @@ class Context:
 
 
 CALLERID_MATCHER = re.compile(
-    r'^(?:"(.+)"|([a-zA-Z0-9\-\.\!%\*_\+`\'\~]+)) ?(?:<(\+?[0-9\*#]+)>)?$'
+    r'^ *(?:"(.+)"|([\w\-\.\!%\*_\+`\'\~ ]*[^ "])) *(?:<(\+?[0-9\*#]+)>)?$'
 ).match
 CALLERIDNUM_MATCHER = re.compile(r'^\+?[0-9\*#]+$').match
 
@@ -1027,7 +1027,7 @@ class CallerID:
     @staticmethod
     def parse(callerid):
         logger.debug('caller_id parse: parsing "%s"', callerid)
-        m = CALLERID_MATCHER(callerid)
+        m = CALLERID_MATCHER(callerid) if callerid else None
 
         if not m:
             logger.debug('caller_id parse: could not match callerid, giving up')

--- a/wazo_agid/tests/test_objects.py
+++ b/wazo_agid/tests/test_objects.py
@@ -1,4 +1,4 @@
-# Copyright 2023-2024 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2023-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
@@ -7,7 +7,7 @@ from unittest import TestCase
 
 from hamcrest import assert_that, is_
 
-from ..objects import VMBox
+from ..objects import CallerID, VMBox
 
 
 class VMBoxFastInit(VMBox):
@@ -43,3 +43,25 @@ class TestVMBox(TestCase):
         vmbox.skipcheckpass = 1
 
         assert_that(vmbox.has_password(), is_(False))
+
+
+class TestCallerID(TestCase):
+    def test_parse(self):
+        test_cases = (
+            ('Test <123>', ('Test', '123')),
+            ('"Test" <+123>', ('Test', '+123')),
+            ('"Test <+123>', None),
+            ('Test" <+123>', None),
+            ('"Test word   " <+123>', ('Test word   ', '+123')),
+            ('Test2 word    <+123>', ('Test2 word', '+123')),
+            ('Test3 word    <123>', ('Test3 word', '123')),
+            ('  Test4 word    <123>', ('Test4 word', '123')),
+            ('a', ('a', None)),
+            ('1', ('1', '1')),
+            ('+123', ('+123', '+123')),
+            ('anonymous', ('anonymous', None)),
+            ('', None),
+            (None, None),
+        )
+        for test_case, expected_result in test_cases:
+            assert CallerID.parse(test_case) == expected_result


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes how inbound/outbound caller ID strings are parsed for AGI features (queues, incalls, outgoing CID); mis-parsing could affect displayed or routed numbers, though behavior is covered by new tests.
> 
> **Overview**
> Relaxes **`CallerID.parse`** so unquoted display names can include **spaces** (and leading/trailing whitespace is tolerated), while keeping quoted names and `<number>` forms. The main regex in `objects.py` is updated accordingly, and **`None`/empty** inputs are handled without matching.
> 
> Adds **`TestCallerID`** with table-driven cases for spaced names, quoted strings, bare numbers, and invalid forms.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65e277a52ca60a0b6073bb0b4b1d8627d4d8294d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->