### PR TITLE
queues: set diversion header/redirecting info variables

### DIFF
--- a/wazo_agid/modules/incoming_queue_set_features.py
+++ b/wazo_agid/modules/incoming_queue_set_features.py
@@ -1,4 +1,4 @@
-# Copyright 2006-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2006-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
@@ -101,6 +101,7 @@ def incoming_queue_set_features(agi, cursor, args):
     agi.set_variable(dv.PICKUPGROUP, ','.join(pickups))
 
     set_call_record_side(agi, queue)
+    _set_redirecting_info(agi, queue)
 
 
 def _set_call_record_toggle(agi, queue):
@@ -109,6 +110,23 @@ def _set_call_record_toggle(agi, queue):
         f'__{dv.QUEUE_DTMF_RECORD_TOGGLE_ENABLED}',
         toggle_enabled,
     )
+
+
+def _set_redirecting_info(agi, queue: objects.Queue) -> None:
+    incall_id = agi.get_variable(dv.INCALL_ID)
+    dstnum = agi.get_variable(dv.DESTINATION_NUMBER)
+
+    if incall_id and dstnum:
+        redirecting_num = dstnum
+        extern_num = dstnum
+    else:
+        redirecting_num = queue.number
+        extern_num = ''
+
+    agi.set_variable(dv.DST_REDIRECTING_NAME, queue.name)
+    agi.set_variable(dv.DST_REDIRECTING_NUM, redirecting_num)
+    agi.set_variable(dv.DST_REDIRECTING_EXTERN_NAME, extern_num)
+    agi.set_variable(dv.DST_REDIRECTING_EXTERN_NUM, extern_num)
 
 
 def _set_wrapup_time(agi, queue):


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small, localized dialplan variable setup on queue entry, following an established group-features pattern with no auth or data-model changes.
> 
> **Overview**
> When a call enters a queue, **`incoming_queue_set_features`** now populates the same **`WAZO_DST_REDIRECTING_*`** dialplan variables used elsewhere for diversion / **REDIRECTING** headers on outbound legs.
> 
> A new **`_set_redirecting_info`** helper sets the queue **name** as redirecting name. If both **`WAZO_INCALL_ID`** and **`WAZO_DSTNUM`** are present (typical DID → queue path), redirecting and external number fields use the destination number; otherwise redirecting number falls back to the **queue number** and external name/number are cleared.
> 
> This aligns queue handling with the existing pattern in group incoming features so **`format_and_set_outgoing_caller_id`** can emit diversion when those variables are set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2358a278c2abe8fa6387d785683a5981193bb7b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->