### PR TITLE
Use nginx for internal wazo-auth requests

### DIFF
--- a/etc/wazo-agid/config.yml
+++ b/etc/wazo-agid/config.yml
@@ -39,8 +39,7 @@ dird:
 # wazo-auth connection settings
 auth:
   host: localhost
-  port: 9497
-  prefix: null
+  port: 80
   https: false
   key_file: /var/lib/wazo-auth-keys/wazo-agid-key.yml
 

--- a/integration_tests/assets/etc/wazo-agid/conf.d/50-default.yml
+++ b/integration_tests/assets/etc/wazo-agid/conf.d/50-default.yml
@@ -2,6 +2,8 @@ debug: true
 listen_address: 0.0.0.0
 auth:
   host: auth
+  port: 9497
+  prefix: null
   username: wazo-agid
   password: secret-key
 bus:

--- a/wazo_agid/bin/agid.py
+++ b/wazo_agid/bin/agid.py
@@ -1,4 +1,4 @@
-# Copyright 2012-2024 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2012-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
@@ -37,8 +37,7 @@ _DEFAULT_CONFIG = {
     },
     'auth': {
         'host': 'localhost',
-        'port': 9497,
-        'prefix': None,
+        'port': 80,
         'https': False,
         'key_file': '/var/lib/wazo-auth-keys/wazo-agid-key.yml',
     },


### PR DESCRIPTION
Points requests to wazo-auth at the nginx internal entry point
(`localhost:80`) instead of the wazo-auth process port, in both the Python
defaults and the shipped `config.yml` (the YAML is loaded on top of the Python
defaults, so both must change).

The `prefix` override is dropped rather than set: `wazo-auth-client` already
defaults to `/api/auth`.

Depends on:

* wazo-platform/wazo-nginx#23 — the internal entry point itself
* wazo-platform/wazo-auth#449 — the wazo-auth location served on it

Both must be deployed before this merges, otherwise internal auth calls 404.
Ticket: TASK-504

Notes:

* Integration test assets now pin `port: 9497` and `prefix: null` explicitly:
  their stacks have no nginx, and those values used to come from the defaults
  changed here.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how every internal auth/token call from wazo-agid is reached and depends on coordinated nginx/auth deployment; mis-timed rollout breaks AGI auth-dependent behavior.
> 
> **Overview**
> **wazo-agid** now talks to **wazo-auth** through the nginx internal entry point (`localhost:80`) instead of the auth daemon port (`9497`). The shipped `config.yml` and Python `_DEFAULT_CONFIG` in `agid.py` are both updated so layered config stays consistent; the explicit `prefix: null` override is removed because `wazo-auth-client` already defaults to `/api/auth`.
> 
> Integration test config (`50-default.yml`) explicitly sets `port: 9497` and `prefix: null` so CI stacks without nginx keep hitting auth directly—values that previously came from the defaults this PR changes.
> 
> **Deploy order:** nginx internal auth routing and wazo-auth on that path must be live before this ships, or internal auth calls will fail (e.g. 404).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b7f5db1621480a3092238a9c5f52599d0c8f954. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->